### PR TITLE
Allow addressable 2.6

### DIFF
--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -22,7 +22,7 @@ clean and semantic DSL for describing your site.
 SitePrism implements the Page Object Model pattern on top of Capybara.'
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
-  s.add_dependency 'addressable', ['~> 2.5']
+  s.add_dependency 'addressable', ['>= 2.5', '<= 2.6']
   s.add_dependency 'capybara', ['~> 3.3']
   s.add_dependency 'site_prism-all_there', ['~> 0.3']
 


### PR DESCRIPTION
Relax dependency requirements for Addressable.

## Type of PR
- Dependency Versioning

## Reasons for Change
Many other gems are now requiring addressable ~>2.6
Reviewing release notes and code changes in addressable there do not appear to be any breaking changes in the addressable 2.6 release.
Change Log - https://github.com/sporkmonger/addressable/blob/master/CHANGELOG.md#addressable-260
Version  Comparison - https://github.com/sporkmonger/addressable/compare/addressable-2.5.2...addressable-2.6.0