### PR TITLE
Section#within - solution for #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Make sure to add your project/company to https://github.com/site-prism/site_pris
 
 We love it when people want to get involved with our Open Source Project.
 
-We have a brief set of setup docs [HERE](https://github.com/site-prism/site_prism/blob/master/development_setup.md)
+We have a brief set of setup docs [HERE](https://github.com/site-prism/site_prism/blob/master/HACKING.md)
 
 ## Supported Rubies / Browsers
 
@@ -498,7 +498,7 @@ end
 
 #### Waiting for an element to become visible
 
-A method that gets added by calling `element` is the 
+A method that gets added by calling `element` is the
 `wait_until_<element_name>_visible` method. Calling this method will
 cause the test to wait for Capybara's default wait time for the element
 to become visible. You can customise the wait time by supplying a number
@@ -1175,7 +1175,7 @@ This allows for pretty tests ...
 ```ruby
 Then(/^there are lots of search_results$/) do
   expect(@results_page.search_results.size).to eq(10)
-  
+
   @home.search_results.each do |result|
     expect(result).to have_title
     expect(result.blurb.text).not_to be_empty
@@ -1387,7 +1387,7 @@ instance of the class when created.
 
 ### Skipping load Validations
 
-Defined load validations can be skipped for one `load` call by 
+Defined load validations can be skipped for one `load` call by
 passing in `with_validations: false`.
 
 ```ruby
@@ -1654,7 +1654,7 @@ as per the code below
 Capybara.configure do |config|
   config.default_max_wait_time = 11 #=> Wait up to 11 seconds for all queries to fail
   # or if you don't want to ever wait
-  config.default_max_wait_time = 0 #=> Don't ever wait! 
+  config.default_max_wait_time = 0 #=> Don't ever wait!
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -936,7 +936,7 @@ Then(/^the home page menu contains a link to the various search functions$/) do
 end
 ```
 
-Note that on individual sections it's possible to pass a block directly to the section without using `within`.  Because the block is executed only during Section initialization this won't work when accessing a single Section from an array of Sections.  For that reason we recommend using `within` which works in either case.
+Note that on an individual section it's possible to pass a block directly to the section without using `within`.  Because the block is executed only during `Section` initialization this won't work when accessing a single Section from an array of Sections.  For that reason we recommend using `within` which works in either case.
 
 ```ruby
 Then(/^the home page menu contains a link to the various search functions$/) do

--- a/features/section.feature
+++ b/features/section.feature
@@ -13,6 +13,11 @@ Feature: Page Sections
     Then I can access elements within the section using a block
     But I cannot access elements that are not in the section using a block
 
+  Scenario: access elements in the section by passing a block to within
+    When I navigate to the home page
+    Then I can execute elements in the context of a section by passing a block to within
+    But I cannot access elements that are not in the section using within
+
   Scenario: section in a section
     When I navigate to the nested section page
     Then I can see a section in a section

--- a/features/sections.feature
+++ b/features/sections.feature
@@ -16,6 +16,6 @@ Feature: Interaction with groups of elements
     When I navigate to the nested section page
     Then I can see a collection of anonymous sections
 
-  Scenario: access elements in the section by passing a block
+  Scenario: can access elements in the section by passing a block to within
     When I navigate to the nested section page
-    Then I can execute in the context of a section using a block
+    Then I can execute in the context of each section by passing a block to within

--- a/features/sections.feature
+++ b/features/sections.feature
@@ -15,3 +15,7 @@ Feature: Interaction with groups of elements
   Scenario: anonymous sections collection
     When I navigate to the nested section page
     Then I can see a collection of anonymous sections
+
+  Scenario: access elements in the section by passing a block
+    When I navigate to the nested section page
+    Then I can execute in the context of a section using a block

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -27,9 +27,31 @@ Then('I can access elements within the section using a block') do
   expect(block_inner_executions).to eq 1
 end
 
+Then('I can execute elements in the context of a section by passing a block to within') do
+  block_inner_executions = 0
+
+  expect(@test_site.home).to have_people
+
+  @test_site.home.people.within do |section|
+    block_inner_executions += 1
+
+    expect(section.headline.text).to eq('People')
+
+    expect(section).to have_individuals(count: 4)
+  end
+
+  expect(block_inner_executions).to eq 1
+end
+
 Then('I cannot access elements that are not in the section using a block') do
   expect do
     @test_site.home.people { |section| expect(section).to have_not_here }
+  end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+end
+
+Then('I cannot access elements that are not in the section using within') do
+  expect do
+    @test_site.home.people.within { |section| expect(section).to have_not_here }
   end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
 end
 

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -12,13 +12,19 @@ Then('I can see a section in a section') do
 end
 
 Then('I can access elements within the section using a block') do
+  block_inner_executions = 0
+
   expect(@test_site.home).to have_people
 
   @test_site.home.people do |section|
+    block_inner_executions += 1
+
     expect(section.headline.text).to eq('People')
 
     expect(section).to have_individuals(count: 4)
   end
+
+  expect(block_inner_executions).to eq 1
 end
 
 Then('I cannot access elements that are not in the section using a block') do

--- a/features/step_definitions/sections_steps.rb
+++ b/features/step_definitions/sections_steps.rb
@@ -17,3 +17,24 @@ Then('I can see a collection of anonymous sections') do
 
   expect(anonymous_sections.size).to eq(2)
 end
+
+
+Then('I can execute in the context of a section using a block') do
+  block_inner_executions = 0
+
+  expect(@test_site.nested_sections).to have_search_results(count: 4)
+
+  @test_site.nested_sections.search_results.first do |sec|
+    block_inner_executions += 1
+    expect(sec).to be_an_instance_of(SitePrism::Section)
+    expect(sec).to have_text('Result 0')
+  end
+
+  @test_site.nested_sections.search_results.last do |sec|
+    block_inner_executions += 1
+    expect(sec).to be_an_instance_of(SitePrism::Section)
+    expect(sec).to have_text('Result 3')
+  end
+
+  expect(block_inner_executions).to eq 2
+end

--- a/features/step_definitions/sections_steps.rb
+++ b/features/step_definitions/sections_steps.rb
@@ -36,5 +36,12 @@ Then('I can execute in the context of each section by passing a block to within'
     expect(sec).to have_text('Result 3')
   end
 
-  expect(block_inner_executions).to eq 2
+  @test_site.nested_sections.search_results.each do |sec|
+    block_inner_executions += 1
+
+    expect(sec).to be_an_instance_of(SearchResults)
+    expect(sec).to have_text(/Result/)
+  end
+
+  expect(block_inner_executions).to eq 6
 end

--- a/features/step_definitions/sections_steps.rb
+++ b/features/step_definitions/sections_steps.rb
@@ -18,21 +18,21 @@ Then('I can see a collection of anonymous sections') do
   expect(anonymous_sections.size).to eq(2)
 end
 
-
-Then('I can execute in the context of a section using a block') do
+Then('I can execute in the context of each section by passing a block to within') do
   block_inner_executions = 0
 
   expect(@test_site.nested_sections).to have_search_results(count: 4)
 
-  @test_site.nested_sections.search_results.first do |sec|
+  @test_site.nested_sections.search_results.first.within do |sec|
     block_inner_executions += 1
-    expect(sec).to be_an_instance_of(SitePrism::Section)
+
+    expect(sec).to be_an_instance_of(SearchResults)
     expect(sec).to have_text('Result 0')
   end
 
-  @test_site.nested_sections.search_results.last do |sec|
+  @test_site.nested_sections.search_results.last.within do |sec|
     block_inner_executions += 1
-    expect(sec).to be_an_instance_of(SitePrism::Section)
+    expect(sec).to be_an_instance_of(SearchResults)
     expect(sec).to have_text('Result 3')
   end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,6 +15,8 @@ require 'site_prism'
 require_relative 'js_helper'
 require_relative 'sections/all'
 
+SimpleCov.start if defined? SimpleCov
+
 Capybara.register_driver :site_prism do |app|
   browser = ENV.fetch('browser', 'firefox').to_sym
   # Needed whilst we support Webdriver 3.x (Can be removed once we only support 4.x)

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -31,7 +31,7 @@ module SitePrism
       Capybara.within(@root_element) { yield(self) } if block_given?
     end
 
-    def within(&block)
+    def within
       Capybara.within(@root_element) { yield(self) }
     end
 

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -31,6 +31,10 @@ module SitePrism
       Capybara.within(@root_element) { yield(self) } if block_given?
     end
 
+    def within(&block)
+      Capybara.within(@root_element) { yield(self) }
+    end
+
     # Capybara::DSL module "delegates" Capybara methods to the "page" method
     # as such we need to overload this method so that the correct scoping
     # occurs and calls within a section (For example section.find(element))

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -25,10 +25,10 @@ module SitePrism
         nil
     end
 
-    def initialize(parent, root_element)
+    def initialize(parent, root_element, &block)
       @parent = parent
       @root_element = root_element
-      Capybara.within(@root_element) { yield(self) } if block_given?
+      within(&block) if block_given?
     end
 
     def within

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.5']
-  s.add_dependency 'capybara', ['~> 3.3']
+  s.add_dependency 'capybara', ['<= 3.29']
   s.add_dependency 'site_prism-all_there', ['>= 0.3.1', '< 1.0']
 
   s.add_development_dependency 'cucumber', ['~> 3.1']

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'site_prism-all_there', ['>= 0.3.1', '< 1.0']
 
   s.add_development_dependency 'cucumber', ['~> 3.1']
+  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake', ['>= 12.3']
   s.add_development_dependency 'rspec', ['~> 3.8']
   s.add_development_dependency 'rubocop', ['~> 0.75.0']

--- a/spec/site_prism/section_spec.rb
+++ b/spec/site_prism/section_spec.rb
@@ -282,7 +282,7 @@ set_default_search_arguments within section class"
   end
 
   describe '#within' do
-    it "passes the block to Capybara#within" do
+    it 'passes the block to Capybara#within' do
       expect(Capybara).to receive(:within).with(locator)
 
       section_without_block.within { :noop }

--- a/spec/site_prism/section_spec.rb
+++ b/spec/site_prism/section_spec.rb
@@ -77,6 +77,7 @@ describe SitePrism::Section do
       it { is_expected.to respond_to(:wait_until_section_visible) }
       it { is_expected.to respond_to(:wait_until_section_invisible) }
       it { is_expected.to respond_to(:all_there?) }
+      it { is_expected.to respond_to(:within) }
     end
 
     context 'when second argument is not a Class but a block is given' do
@@ -96,6 +97,7 @@ describe SitePrism::Section do
       it { is_expected.to respond_to(:wait_until_anonymous_section_visible) }
       it { is_expected.to respond_to(:wait_until_anonymous_section_invisible) }
       it { is_expected.to respond_to(:all_there?) }
+      it { is_expected.to respond_to(:within) }
     end
 
     context 'when second argument is a Class and a block is given' do
@@ -115,6 +117,7 @@ describe SitePrism::Section do
       it { is_expected.to respond_to(:wait_until_anonymous_section_visible) }
       it { is_expected.to respond_to(:wait_until_anonymous_section_invisible) }
       it { is_expected.to respond_to(:all_there?) }
+      it { is_expected.to respond_to(:within) }
     end
 
     context 'when second argument is not a Class and no block is given' do
@@ -275,6 +278,14 @@ set_default_search_arguments within section class"
 
         page.new_element
       end
+    end
+  end
+
+  describe '#within' do
+    it "passes the block to Capybara#within" do
+      expect(Capybara).to receive(:within).with(locator)
+
+      section_without_block.within { :noop }
     end
   end
 


### PR DESCRIPTION
## Overview

Hi Luke,
This is one of the potential ways to resolve #21 that I discussed so long ago.  I'm sorry it took this long to get you anything for this.  Even more so, since this turned out to be much simpler than I anticipated.

#### Issue Review #21 
In #21 we had the problem that the following was OK:

```rb
page.my_section do |sec|
  expect(sec).to have_secs_element
end
```

But the following silently ignored the block because when the block is executed in the above, it's executed as part of the `initialize` method.
```rb
page.my_sections.first do |sec|
  expect(sec).to have_secs_element
end
```

**In this case the sections are initialized and put into an Array.  Initialization has passed and Array#first doesn't use a block.**

#### This change
With this change you can do basically the same thing by calling `#within`.
```rb
page.my_sections.first.within do |sec|
  expect(sec).to have_secs_element
end
```

### Other Alternatives

We could implement a `SectionsCollection` class that serves as the `Array` for Sections.  
We would need the basic methods such as:
* `first`
* `last`
* `map`
* `each`

These could take a block as needed.

Capybara does something similar with [Capybara::Result](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara/Result) which is the result class for `page.all('.locator')`

That would obviously be more complex and I'm not sure we have a strong need for it yet, thoughts? Regardless, I think this actually would be useful as a start for that, as we'd still want a good way to execute easily in the context of a section at will.

## TODO / Questions

* docs -   Figured I would see how you felt about it first @luke-hill 
* do we want to discourage the use of sending a block to Section#new (which is maybe not obvious to many users) and instead encourage using #within ?
* I want to give this a test on one of my repos JIC
* should I bump the version?
* I added a pry **dev** dependency - it's a very common gem and I end up pulling it in every time I work on site-prism then undoing that add.