### PR TITLE
More accurate RSpec `defined?` check

### DIFF
--- a/lib/site_prism/dsl.rb
+++ b/lib/site_prism/dsl.rb
@@ -181,7 +181,7 @@ module SitePrism
       def add_helper_methods(name, *find_args)
         create_existence_checker(name, *find_args)
         create_nonexistence_checker(name, *find_args)
-        create_rspec_existence_matchers(name) if defined?(RSpec)
+        create_rspec_existence_matchers(name) if defined?(RSpec::Matchers)
         create_visibility_waiter(name, *find_args)
         create_invisibility_waiter(name, *find_args)
       end


### PR DESCRIPTION
Some projects have an edge-case where RSpec is defined, but `RSpec::Matchers` is not, in which case `create_rspec_existence_matchers` will break trying to add existence matchers to an undefined module.

This PR adds a more granular check before running `create_rspec_existence_matchers`.