### PR TITLE
Bug fix: negated existence matchers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,13 +11,10 @@
 Metrics/ClassLength:
   Max: 120
 
-Metrics/MethodLength:
-  Max: 20
-
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 221
+  Max: 207
 
 # Offense count: 2
 RSpec/AnyInstance:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,10 +11,13 @@
 Metrics/ClassLength:
   Max: 120
 
+Metrics/MethodLength:
+  Max: 20
+
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 207
+  Max: 221
 
 # Offense count: 2
 RSpec/AnyInstance:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
-## [Unreleased]
+## Unreleased
+### Removed
+
+### Added
+
+### Changed
+
+
+### Fixed
+
+- SitePrism's RSpec matchers fall back to behaviour matching that of the standard RSpec
+  built-ins when called on anything that is not a SitePrism page.
+([lparry])
+
+## [3.5] - 2020-06-04
+
 ### Removed
 - ...
 
@@ -1143,3 +1158,4 @@ impending major rubocop release
 [oieioi]:         https://github.com/oieioi
 [anuj-ssharma]:   https://github.com/anuj-ssharma
 [sos4nt]:         https://github.com/sos4nt
+[lparry]:         https://github.com/lparry

--- a/lib/site_prism.rb
+++ b/lib/site_prism.rb
@@ -5,15 +5,16 @@ require 'addressable/template'
 
 module SitePrism
   autoload :AddressableUrlMatcher, 'site_prism/addressable_url_matcher'
-  autoload :Deprecator, 'site_prism/deprecator'
   autoload :DSL, 'site_prism/dsl'
+  autoload :Deprecator, 'site_prism/deprecator'
   autoload :ElementChecker, 'site_prism/element_checker'
-  autoload :RecursionChecker, 'site_prism/recursion_checker'
   autoload :Logger, 'site_prism/logger'
   autoload :Page, 'site_prism/page'
+  autoload :RecursionChecker, 'site_prism/recursion_checker'
+  autoload :RspecMatchers, 'site_prism/rspec_matchers'
   autoload :Section, 'site_prism/section'
-  autoload :Waiter, 'site_prism/waiter'
   autoload :Timer, 'site_prism/timer'
+  autoload :Waiter, 'site_prism/waiter'
 
   class << self
     attr_reader :use_all_there_gem

--- a/lib/site_prism/dsl.rb
+++ b/lib/site_prism/dsl.rb
@@ -192,7 +192,7 @@ module SitePrism
       def add_helper_methods(name, *find_args)
         create_existence_checker(name, *find_args)
         create_nonexistence_checker(name, *find_args)
-        create_rspec_existence_matchers(name) if defined?(RSpec)
+        SitePrism::RspecMatchers.create_rspec_existence_matchers(name) if defined?(RSpec)
         create_visibility_waiter(name, *find_args)
         create_invisibility_waiter(name, *find_args)
       end
@@ -202,30 +202,6 @@ module SitePrism
           create_error_method(proposed_method_name)
         else
           yield
-        end
-      end
-
-      def create_rspec_existence_matchers(element_name)
-        matcher = "have_#{element_name}"
-        object_method = "has_#{element_name}?"
-        negated_object_method = "has_no_#{element_name}?"
-
-        RSpec::Matchers.define matcher do |*args|
-          match { |actual| actual.public_send(object_method, *args) }
-          match_when_negated do |actual|
-            if actual.respond_to?(negated_object_method)
-              actual.public_send(negated_object_method, *args)
-            else
-              warning = [
-                "#{matcher} was handled by a matcher added by site prism, but the object under",
-                "test does not respond to #{negated_object_method} and is probably not a site",
-                'prism page. Attempting to mimic the rspec standard matcher that site prism',
-                'replaced.',
-              ].join(' ')
-              SitePrism.logger.debug(warning)
-              !actual.public_send(object_method, *args)
-            end
-          end
         end
       end
 

--- a/lib/site_prism/rspec_matchers.rb
+++ b/lib/site_prism/rspec_matchers.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module SitePrism
+  class RspecMatchers
+    def self.create_rspec_existence_matchers(element_name)
+      new(element_name).create_rspec_existence_matchers
+    end
+
+    def initialize(element_name)
+      @element_name = element_name
+    end
+
+    def create_rspec_existence_matchers
+      matcher = "have_#{element_name}"
+      object_method = "has_#{element_name}?"
+      negated_object_method = "has_no_#{element_name}?"
+      useless_method_to_save_lines(
+        matcher,
+        object_method,
+        negated_object_method,
+        method(:log_warning)
+      )
+    end
+
+    private
+
+    def useless_method_to_save_lines(matcher, object_method, negated_object_method, log_warning)
+      RSpec::Matchers.define matcher do |*args|
+        match { |actual| actual.public_send(object_method, *args) }
+        match_when_negated do |actual|
+          if actual.respond_to?(negated_object_method)
+            return actual.public_send(negated_object_method, *args)
+          end
+
+          log_warning.call(matcher, negated_object_method)
+          !actual.public_send(object_method, *args)
+        end
+      end
+    end
+
+    attr_reader :element_name
+
+    def log_warning(matcher, negated_object_method)
+      warning = [
+        "#{matcher} was handled by a matcher added by site prism, but the object under",
+        "test does not respond to #{negated_object_method} and is probably not a site",
+        'prism page. Attempting to mimic the rspec standard matcher that site prism',
+        'replaced.',
+      ].join(' ')
+      SitePrism.logger.debug(warning)
+    end
+  end
+end

--- a/spec/site_prism/element_spec.rb
+++ b/spec/site_prism/element_spec.rb
@@ -33,6 +33,28 @@ describe SitePrism do
         expect(subject).not_to have_element_two
       end
 
+      context 'when other classes coincidentally have the overlapping methods defined' do
+        subject { anonymous_test_class.new }
+
+        let!(:anonymous_site_prism_class) do # rubocop:disable RSpec/LetSetup
+          Class.new(SitePrism::Page) do
+            element :foo, :xpath, '//a[@class="b"]//c[@class="d"]'
+          end
+        end
+
+        let!(:anonymous_test_class) do
+          Class.new do
+            def has_foo?
+              false
+            end
+          end
+        end
+
+        it 'does not break the normal existence matcher behaviour' do
+          expect(subject).not_to have_foo
+        end
+      end
+
       it 'raises a warning when the name starts with no_' do
         log_messages = capture_stdout do
           described_class.log_level = :WARN


### PR DESCRIPTION
I ran into an interesting problem today where the coincidental overlap of a site prism method with that on a regular class, meant that the negated existence matcher in some existing code stopped working.

This appears to be because of https://github.com/natritmeyer/site_prism/pull/390, expecting a non-standard method to always be present in order to have site prism wait correctly.

I've added a `respond_to?` check for the negated matcher, and now fall back to the standard `!positive_matcher` when no such method exists.