### PR TITLE
Fix section page behavior

### DIFF
--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.5']
-  s.add_dependency 'capybara', ['>= 3.8', '<= 3.29']
+  s.add_dependency 'capybara', ['>= 3.8']
   s.add_dependency 'site_prism-all_there', ['>= 0.3.1', '< 1.0']
 
   s.add_development_dependency 'cucumber', ['~> 3.1']


### PR DESCRIPTION
@luke-hill I believe this is what you really want Section to be doing.  I've only written this to work properly for Ruby 2.7, the meta programming needs some additions to work correctly for lower versions of Ruby.  You should probably also look at removing the `page` method in Section because it doesn't make a lot of sense as currently written/implemented, and probably shouldn't have been public in the first place.