### PR TITLE
Clarify wait behavior and element method behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Removed
 
 ### Added
+- Updated README to clarify `displayed?` wait behavior and finder method delgation ([asavageiv])
 
 ### Changed
 
@@ -17,7 +18,7 @@
 ([luke-hill])
 
 - Refined SitePrism's `Waiter.wait_until_true` logic
-  - SitePrism can now be used with `Timecop.freeze` and Rails' `travel_to`  
+  - SitePrism can now be used with `Timecop.freeze` and Rails' `travel_to`
   - `FrozenInTimeError` was removed as it is no longer needed
 ([sos4nt])
 
@@ -34,7 +35,7 @@
 - Added new logging that will notify users (And team!), when a user creates a name with a `no_` prefix
   - This will cause race condition conflicts which are intractable, and as such will be banned in a later release
 ([anuj-ssharma]) & ([luke-hill])
- 
+
 ### Fixed
 - Fixed warnings about keyword arguments in Ruby 2.7
   - The official explanation of keyword arguments in Ruby 2.7 can be found [HERE](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
@@ -131,7 +132,7 @@ will either be changing for version4 or being removed entirely.
   - When setting it to `:none` (The default), the behaviour is identical
   - When setting it to `:one`, `#all_there?` will recurse through every section and sections item
   that has been defined, and run `#all_there?` on those items also.
-  
+
   **NB: This is very much a working prototype, and additional refactors / tweaks will be forthcoming**
 ([luke-hill])
 
@@ -183,7 +184,7 @@ impending major rubocop release
 - Travis now uses `webdrivers` gem to build and mitigate driver issues
 ([luke-hill])
 
-- SitePrism can now detect if Time has been frozen (i.e. with Timecop), whilst using `.wait_until_true` 
+- SitePrism can now detect if Time has been frozen (i.e. with Timecop), whilst using `.wait_until_true`
 ([dkniffin])
 
 ## [3.1] - 2019-03-26
@@ -256,7 +257,7 @@ impending major rubocop release
   - Are now slightly optimised making 2 less checks per batch (One less check per initial run)
   - Actually perform the checks they were documented to (They didn't run against a url without a block)
   - Fix `#loaded` `attr_accessor` to actually cache - It never did! (This speeds up `#loaded?` calls)
-  - Add a couple more specs and a bunch of new scenarios to cover these missing edge cases 
+  - Add a couple more specs and a bunch of new scenarios to cover these missing edge cases
 ([luke-hill])
 
 ## [3.0.2] - 2019-01-21
@@ -291,13 +292,13 @@ impending major rubocop release
   - All files now match their class names
   - All sample items are now more succinctly named
   - Removed some of the slower JS injected components in favour of the Slow/Vanishing pages
-([luke-hill]) 
+([luke-hill])
 
 - Item mapping (A large component of the site_prism build phase) has been refactored and slightly extended
   - Initially we will map the "type" of each site_prism item that has been mapped.
   - The public interface has been refactored to accommodate that and provide a like for like replacement
   - This will be the base of the work required to extend `#all_there?` to provide recursion capabilities
-([luke-hill]) 
+([luke-hill])
 
 - Upped some gem dependencies
   - `rubocop` now is finally upped to v60 (More to come)
@@ -305,7 +306,7 @@ impending major rubocop release
   - `capybara` is now only supported on `2.18` outside of the `3.x` series
   - `cucumber` / `selenium-webdriver` both bumped one minor version
 ([luke-hill])
-  
+
 ### Fixed
 - A config setting that causes local single test (rspec/cucumber) runs to crash
   - This is due to `simplecov` caching dual results
@@ -527,7 +528,7 @@ impending major rubocop release
 ([luke-hill])
 
 - Rewrite `ElementContainer` by using `klass.extend`, removing several `self.class` calls
-([ineverov]) 
+([ineverov])
 
 - Added positive and negative timing tests to several scenarios in `waiting.feature`
 ([luke-hill])
@@ -676,7 +677,7 @@ impending major rubocop release
   - Required Ruby Version is now 2.0+
 ([luke-hill])
 
-- Capped Development dependencies for `cucumber (2.4)` and `selenium-webdriver (3.4)` 
+- Capped Development dependencies for `cucumber (2.4)` and `selenium-webdriver (3.4)`
   - Establish a baseline for what is expected with these dependencies
   - Suite is still being reworked (So unsure of what results to expect)
 ([luke-hill])
@@ -782,13 +783,13 @@ impending major rubocop release
   - Substituting all parts of url_matcher into the relevant types (port/fragment e.t.c.)
   - Only pass the matching test after each component part matches the `url_matcher` set
 ([jmileham])
-  
+
 - Added check for block being passed to page (Will raise error accordingly)
 ([sponte])
 
 ### Changed
 - Altered legacy RSpec syntax in favour of `expect` in tests
-([petergoldstein]) 
+([petergoldstein])
 
 - Extend `#displayed?` to work when a `url_matcher` is templated
 ([jmileham])
@@ -879,7 +880,7 @@ impending major rubocop release
 
 ## [2.3] - 2013-04-05
 ### Added
-- Initial Dynamic URL support 
+- Initial Dynamic URL support
   - Adds new dependency to suite `addressable`
   - Allows templating of URL parameters to be passed in as KVP's
 ([therabidbanana])
@@ -935,7 +936,7 @@ impending major rubocop release
   - `capybara ~> 1.1`
   - `rspec ~> 2.0`
 ([natritmeyer])
-  
+
 - Internal API Changes:
   - `#element_names` is now `#mapped_items` in `SitePrism::Page` and `SitePrism::Section`
   - We now use a `build` method to decide what methods are created for each element/section and in what order
@@ -1156,3 +1157,4 @@ impending major rubocop release
 [anuj-ssharma]:   https://github.com/anuj-ssharma
 [sos4nt]:         https://github.com/sos4nt
 [lparry]:         https://github.com/lparry
+[asavageiv]:      https://github.com/asavageiv

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ matches the page's template and false if it doesn't. It will wait for
 wait time in seconds as the first argument like this:
 
 ```ruby
-expect(@account_page).to be_displayed(10) # wait up to 10 seconds
+@account_page.displayed?(10) # wait up to 10 seconds for display
 ```
 
 #### Specifying parameter values for templated URLs
@@ -432,10 +432,10 @@ as a string.
 
 The `element` method will add a number of methods to instances of the
 particular Page class. The first method added is the name of the
-element. It finds the element using [Capybara::Node::Finders#find](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Finders#find-instance_method)
-returning a [Capybara::Node::Element](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Element) or
-raising [Capybara::ElementNotFound](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/ElementNotFound)
-if the element can not be found. For example:
+element. It finds the element using [Capybara::Node::Finders#find](https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Finders#find-instance_method)
+returning a [Capybara::Node::Element](https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Element) or
+raising [Capybara::ElementNotFound](https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/ElementNotFound)
+if the element can not be found.
 
 ```ruby
 class Home < SitePrism::Page
@@ -459,7 +459,9 @@ end
 #### Testing for the existence of the element
 
 Another method added to the Page class by the `element` method is the
-`has_<element_name>?` method. Using the same example as above:
+`has_<element_name>?` method.
+This method delegates to [Capybara::Node::Matchers#has_selector?](https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Matchers#has_selector%3F-instance_method).
+Using the same example as above:
 
 ```ruby
 class Home < SitePrism::Page
@@ -485,13 +487,13 @@ Then(/^the search field exists$/) do
 end
 ```
 
-The method delegates to [Capybara::Node::Matchers#has_selector?](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_selector%3F-instance_method)
-
 #### Testing that an element does not exist
 
 To test that an element does not exist on the page, it is not possible to just call
 `#not_to have_search_field`. SitePrism supplies the `#has_no_<element>?` method
-that should be used to test for non-existence. Using the above example:
+that should be used to test for non-existence.
+This method delegates to [Capybara::Node::Matchers#has_no_selector?](https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Matchers#has_no_selector%3F-instance_method)
+Using the above example:
 
 ```ruby
 @home = Home.new
@@ -507,13 +509,12 @@ Then(/^the search field exists$/)do
 end
 ```
 
-The method delegates to [Capybara::Node::Matchers#has_no_selector?](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_no_selector%3F-instance_method)
-
 #### Waiting for an element to become visible
 
 A method that gets added by calling `element` is the
-`wait_until_<element_name>_visible` method. Calling this method will
-cause the test to wait for Capybara's default wait time for the element
+`wait_until_<element_name>_visible` method.
+This method delegates to [Capybara::Node::Matchers#has_selector?](https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Matchers#has_selector%3F-instance_method).
+Calling this method will cause the test to wait for Capybara's default wait time for the element
 to become visible. You can customise the wait time by supplying a number
 of seconds to wait in-line or configuring the default wait time.
 
@@ -523,23 +524,20 @@ of seconds to wait in-line or configuring the default wait time.
 @home.wait_until_search_field_visible(wait: 10)
 ```
 
-The method delegates to [Capybara::Node::Matchers#has_selector?](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_selector%3F-instance_method)
-
 #### Waiting for an element to become invisible
 
 Another method added by calling `element` is the
-`wait_until_<element_name>_invisible` method. Calling this method will
-cause the test to wait for Capybara's default wait time for the element
-to become invisible. You can as with the visibility waiter, customise
-the wait time in the same way.
+`wait_until_<element_name>_invisible` method.
+This method delegates to [Capybara::Node::Matchers#has_no_selector?](https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Matchers#has_no_selector%3F-instance_method).
+Calling this method will cause the test to wait for Capybara's default
+wait time for the element to become invisible. You can as with the visibility
+waiter, customise the wait time in the same way.
 
 ```ruby
 @home.wait_until_search_field_invisible
 # or...
 @home.wait_until_search_field_invisible(wait: 10)
 ```
-
-The method delegates to [Capybara::Node::Matchers#has_no_selector?](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_no_selector%3F-instance_method)
 
 #### CSS Selectors vs. XPath Expressions
 

--- a/README.md
+++ b/README.md
@@ -298,7 +298,13 @@ expect(@account_page).to be_displayed
 ```
 
 Calling `#displayed?` will return true if the browser's current URL
-matches the page's template and false if it doesn't.
+matches the page's template and false if it doesn't. It will wait for
+`Capybara.default_max_wait_time` seconds or you can pass an explicit
+wait time in seconds as the first argument like this:
+
+```ruby
+expect(@account_page).to be_displayed(10) # wait up to 10 seconds
+```
 
 #### Specifying parameter values for templated URLs
 

--- a/README.md
+++ b/README.md
@@ -431,8 +431,11 @@ as a string.
 #### Accessing the individual element
 
 The `element` method will add a number of methods to instances of the
-particular Page class. The first method to be added is the name of the
-element. So using the following example:
+particular Page class. The first method added is the name of the
+element. It finds the element using [Capybara::Node::Finders#find](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Finders#find-instance_method)
+returning a [Capybara::Node::Element](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Element) or
+raising [Capybara::ElementNotFound](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/ElementNotFound)
+if the element can not be found. For example:
 
 ```ruby
 class Home < SitePrism::Page
@@ -482,6 +485,8 @@ Then(/^the search field exists$/) do
 end
 ```
 
+The method delegates to [Capybara::Node::Matchers#has_selector?](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_selector%3F-instance_method)
+
 #### Testing that an element does not exist
 
 To test that an element does not exist on the page, it is not possible to just call
@@ -502,6 +507,8 @@ Then(/^the search field exists$/)do
 end
 ```
 
+The method delegates to [Capybara::Node::Matchers#has_no_selector?](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_no_selector%3F-instance_method)
+
 #### Waiting for an element to become visible
 
 A method that gets added by calling `element` is the
@@ -516,6 +523,8 @@ of seconds to wait in-line or configuring the default wait time.
 @home.wait_until_search_field_visible(wait: 10)
 ```
 
+The method delegates to [Capybara::Node::Matchers#has_selector?](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_selector%3F-instance_method)
+
 #### Waiting for an element to become invisible
 
 Another method added by calling `element` is the
@@ -529,6 +538,8 @@ the wait time in the same way.
 # or...
 @home.wait_until_search_field_invisible(wait: 10)
 ```
+
+The method delegates to [Capybara::Node::Matchers#has_no_selector?](https://www.rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Matchers#has_no_selector%3F-instance_method)
 
 #### CSS Selectors vs. XPath Expressions
 


### PR DESCRIPTION
Clarify that displayed? waits for the element to appear according to Capybara's default wait time by default and can be given a wait time argument.

Clarify that the element finding methods delegate to Capybara methods.

This will make it easier for users to understand the behavior of SitePrism as it relates to the underlying Capybara behavior and can take advantage of improvements in Capybara's documentation.