### PR TITLE
Increase maximum allowed Capybara version to <= 3.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 ### Fixed
+- Updated the maximum version of Capybara to `<= 3.33` to support Ruby 2.7+
 
 ## [3.6] - 2020-08-17
 ### Added

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -61,7 +61,7 @@ Then('access to elements is constrained to those within the section') do
   expect(@test_site.home.has_welcome_message?).to be true
 
   @test_site.home.people do |section|
-    expect(section).to have_no_css('.welcome')
+    expect(section.has_css?('.welcome')).to be false
 
     expect { section.has_welcome_message? }.to raise_error(NoMethodError)
   end

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
   s.add_dependency 'addressable', ['~> 2.5']
-  s.add_dependency 'capybara', ['>= 3.8', '<= 3.29']
+  s.add_dependency 'capybara', ['>= 3.8', '<= 3.33']
   s.add_dependency 'site_prism-all_there', ['>= 0.3.1', '< 1.0']
 
   s.add_development_dependency 'cucumber', ['~> 3.1']


### PR DESCRIPTION
Capybara 3.28.x includes code that throws keyword parameter deprecation
warnings in Ruby 2.7 and does not work in Ruby 3+.

These issues were fixed in 3.30.0 and all versions up to 3.32.0 are
supported by Ruby 2.4 (currently set in .ruby-version)