### PR TITLE
Upgrade addressable gem from 2.5 to 2.8 to remediate vulnerability

### DIFF
--- a/gemfiles/Gemfile.low_spec
+++ b/gemfiles/Gemfile.low_spec
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'addressable', '< 2.6'
+gem 'addressable', '< 2.8'
 gem 'capybara', '< 3.12'
 gem 'nokogiri', '< 1.11'
 gem 'selenium-webdriver', '< 3.13'

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 ' SitePrism implements the Page Object Model pattern on top of Capybara.'
   s.files        = Dir.glob('lib/**/*') + %w[LICENSE.md README.md]
   s.require_path = 'lib'
-  s.add_dependency 'addressable', ['~> 2.5']
+  s.add_dependency 'addressable', ['~> 2.8']
   s.add_dependency 'capybara', ['~> 3.8']
   s.add_dependency 'site_prism-all_there', ['>= 0.3.1', '< 1.0']
 


### PR DESCRIPTION
Remediation
Upgrade addressable to version 2.8.0 or later. For example:

gem "addressable", ">= 2.8.0"
Always verify the validity and compatibility of suggestions with your codebase.

Details
GHSA-jxhc-q857-3j6g
high severity
Vulnerable versions: > 2.3.0, <= 2.7.0
Patched version: 2.8.0

Impact
Within the URI template implementation in Addressable, a maliciously crafted template may result in uncontrolled resource consumption, leading to denial of service when matched against a URI. In typical usage, templates would not normally be read from untrusted user input, but nonetheless, no previous security advisory for Addressable has cautioned against doing this. Users of the parsing capabilities in Addressable but not the URI template capabilities are unaffected.

Patches
The vulnerability was introduced in version 2.3.0 (previously yanked) and has been present in all subsequent versions up to, and including, 2.7.0. It is fixed in version 2.8.0.

Workarounds
The vulnerability can be avoided by only creating Template objects from trusted sources that have been validated not to produce catastrophic backtracking.

References
https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
https://cwe.mitre.org/data/definitions/1333.html
https://www.regular-expressions.info/catastrophic.html