### PR TITLE
Add sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Capybara.configure do |config|
 end
 ```
 
+Sample is [here](./sample/)
+
 ### Using SitePrism with RSpec
 
 If you're using rspec instead, here's what needs requiring:

--- a/sample/Gemfile
+++ b/sample/Gemfile
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'capybara'
 gem 'cucumber'
+gem 'rspec-expectations'
 gem 'selenium-webdriver'
 gem 'site_prism'
-gem 'rspec-expectations'

--- a/sample/Gemfile
+++ b/sample/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'capybara'
+gem 'cucumber'
+gem 'selenium-webdriver'
+gem 'site_prism'
+gem 'rspec-expectations'

--- a/sample/features/step_definitions/steps.rb
+++ b/sample/features/step_definitions/steps.rb
@@ -13,6 +13,7 @@ Capybara.configure do |config|
 end
 
 # define sections used on multiple pages or multiple times on one page
+
 class Menu < SitePrism::Section
   element :mail, 'a[href*="mail.google.com"]'
   element :news, 'a[href*="news.google.com"]'

--- a/sample/features/step_definitions/steps.rb
+++ b/sample/features/step_definitions/steps.rb
@@ -1,0 +1,82 @@
+require 'capybara/cucumber'
+require 'selenium-webdriver'
+require 'site_prism'
+
+Capybara.register_driver :site_prism do |app|
+  browser = ENV.fetch('browser', 'firefox').to_sym
+  Capybara::Selenium::Driver.new(app, browser: browser)
+end
+
+# Then tell Capybara to use the Driver you've just defined as its default driver
+Capybara.configure do |config|
+  config.default_driver = :site_prism
+end
+
+# define sections used on multiple pages or multiple times on one page
+class Menu < SitePrism::Section
+  element :mail, 'a[href*="mail.google.com"]'
+  element :news, 'a[href*="news.google.com"]'
+  element :calendar, 'a[href*="calendar.google.com"]'
+end
+
+class SearchResultsItems < SitePrism::Section
+  element :title, 'a', match: :first
+  element :blurb, 'div:nth-child(2) > div > span'
+end
+
+# define pages
+
+class Home < SitePrism::Page
+  set_url 'https://www.google.com/index.html'
+  set_url_matcher(/google.com\/?/)
+
+  element :search_field, 'input[name="q"]'
+  element :search_button, 'input[name="btnK"]'
+  elements :footer_links, '#footer a'
+  section :menu, Menu, 'a.gb_C'
+end
+
+class SearchResults < SitePrism::Page
+  set_url_matcher(/google.com\/search\?.*/)
+
+  section :menu, Menu, 'a.gb_C'
+  sections :search_results_items, SearchResultsItems, 'div.g > div > div'
+
+  def search_result_links
+    search_results_items.map { |result| result.has_title? ? result.title['href'] : nil }
+  end
+end
+
+# now for some tests
+
+When(/^I navigate to the google home page$/) do
+  @home = Home.new
+  @home.load
+end
+
+Then(/^the home page should contain the menu and the search form$/) do
+  @home.wait_until_menu_visible # menu loads after a second or 2, give it time to arrive
+  expect(@home).to have_menu
+  expect(@home).to have_search_field
+  expect(@home).to have_search_button
+end
+
+When(/^I search for Sausages$/) do
+  @home.search_field.set 'Sausages'
+  @home.search_button.click
+end
+
+Then(/^the search results page is displayed$/) do
+  @results_page = SearchResults.new
+  expect(@results_page).to be_displayed
+end
+
+Then(/^the search results page contains 10 individual search results$/) do
+  @results_page.wait_until_search_results_items_visible
+  expect(@results_page).to have_search_results_items(minimum: 1)
+end
+
+Then(/^the search results contain a link to the wikipedia sausages page$/) do
+  # english only
+  expect(@results_page.search_result_links).to include('wikipedia.org/wiki/Sausage')
+end

--- a/sample/features/synopsis.feature
+++ b/sample/features/synopsis.feature
@@ -1,0 +1,11 @@
+Feature: Synopsis Sample
+  Example: display example
+    When I navigate to the google home page
+    Then the home page should contain the menu and the search form
+
+  Example: input and expect example
+    When I navigate to the google home page
+    When I search for Sausages
+    Then the search results page is displayed
+    Then the search results page contains 10 individual search results
+    Then the search results contain a link to the wikipedia sausages page

--- a/sample/readme.md
+++ b/sample/readme.md
@@ -1,0 +1,6 @@
+## Setup
+1. install firefox and [geckodriver](https://github.com/mozilla/geckodriver)
+2. `bundle install`
+
+## Run
+`bundle exec cucumber features/synopsis.feature`


### PR DESCRIPTION
[Propose]

I wanted to use this gem, so I did `gem install site_prism` to install it. After that, I read #using-siteprism-with-cucumber and found out how to integrate it. However, I couldn't figure out how to use site_prism specifically.

There is a description that seems to work as #synopsis, but when I tried to make that description work as code, it didn't execute.

I think it would be easier to get people to use this gem if I could make it easy to install and try it out, so I made a sample. Can you please take this in?