### PR TITLE
Require Capybara::DSL before using it

### DIFF
--- a/lib/site_prism.rb
+++ b/lib/site_prism.rb
@@ -4,6 +4,7 @@ require 'site_prism/error'
 require 'site_prism/all_there'
 
 require 'addressable/template'
+require 'capybara/dsl'
 require 'forwardable'
 
 require 'site_prism/addressable_url_matcher'


### PR DESCRIPTION
`SitePrism::DSL` uses `Capybara::DSL` but never requires it to be loaded.

This was never noticed since `SitePrism::DSL` was autoloaded and by the time it was actually invoked, `capybara` was usually loaded by some other part of the codebase.

Since 9725c54247ecf9ed7b42942e1775b2fe5d24420d `SitePrism::DSL` is eagerloaded, resulting in

```
NameError: uninitialized constant Capybara::DSL
```

We fix this by eagerloading `Capybara::DSL` as well.