### PR TITLE
Support for Shadow Root

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,8 @@ Style/Documentation:
 Style/RegexpLiteral:
   EnforcedStyle: slashes
   AllowInnerSlashes: true
+
+# False negative: https://github.com/rubocop/rubocop/issues/12423
+Style/YodaCondition:
+  Exclude:
+    - lib/site_prism/dsl/locators.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Removed
 
 ### Added
+- Support for Shadow Root
+  - You can define it by setting `:shadow_root` to true when defining a `section` ([souchan2000])
 
 ### Changed
 
@@ -1384,3 +1386,4 @@ impending major rubocop release
 [Be-brand]:       https://github.com/Be-brand
 [diego-aslz]:     https://github.com/diego-aslz
 [leoarnold]:      https://github.com/leoarnold
+[souchan2000]:    https://github.com/souchan2000

--- a/README.md
+++ b/README.md
@@ -1686,6 +1686,22 @@ When('I log in') do
 end
 ```
 
+## Shadow Root
+
+SitePrism allows you to interact with Shadow Root too.
+
+### Creating an Shadow Root
+
+You can use the `section` methods and provide the arguments. Specify the reference name for the Shadow Root, the CSS selector to locate it, and add the `:shadow_root` option. For example:
+
+```ruby
+class Home < SitePrism::Page
+  section :foo, '.foo', :shadow_root do
+    element :bar, '.bar'
+  end
+end
+```
+
 ## SitePrism Configuration
 
 SitePrism can be configured to change its behaviour.

--- a/README.md
+++ b/README.md
@@ -1696,7 +1696,7 @@ You can use the `section` methods and provide the arguments. Specify the referen
 
 ```ruby
 class Home < SitePrism::Page
-  section :foo, '.foo', :shadow_root do
+  section :foo, '.foo', shadow_root: true do
     element :bar, '.bar'
   end
 end

--- a/README.md
+++ b/README.md
@@ -1688,11 +1688,12 @@ end
 
 ## Shadow Root
 
-SitePrism allows you to interact with Shadow Root too.
+SitePrism allows you to interact with Shadow Roots too.
 
 ### Creating an Shadow Root
 
-You can use the `section` methods and provide the arguments. Specify the reference name for the Shadow Root, the CSS selector to locate it, and add the `:shadow_root` option. For example:
+You can use the `section` methods and provide the arguments. Specify the reference name for the Shadow Root,
+the CSS selector to locate it, and add the `:shadow_root` option. For example:
 
 ```ruby
 class Home < SitePrism::Page
@@ -1701,6 +1702,8 @@ class Home < SitePrism::Page
   end
 end
 ```
+
+NB: By default `shadow_root` will be set to false
 
 ## SitePrism Configuration
 

--- a/features/section.feature
+++ b/features/section.feature
@@ -90,4 +90,4 @@ Feature: Page Sections
 
   Scenario: shadow-root section
     When I navigate to the shadow root page
-    Then I can see elements from the section composed of Shadow Root
+    Then I can see elements from the section composed of shadow roots

--- a/features/section.feature
+++ b/features/section.feature
@@ -87,3 +87,7 @@ Feature: Page Sections
   Scenario: Get native property from section
     When I navigate to the home page
     Then I can obtain the native property of a section
+
+  Scenario: shadow-root section
+    When I navigate to the shadow root page
+    Then I can see elements from the section composed of Shadow Root

--- a/features/section.feature
+++ b/features/section.feature
@@ -90,4 +90,4 @@ Feature: Page Sections
 
   Scenario: shadow-root section
     When I navigate to the shadow root page
-    Then I can see elements from the section composed of shadow roots
+    Then I can see elements from the section composed of a shadow root

--- a/features/step_definitions/navigation_steps.rb
+++ b/features/step_definitions/navigation_steps.rb
@@ -28,6 +28,10 @@ When('I navigate to the vanishing page') do
   @test_site.vanishing.load
 end
 
+When('I navigate to the shadow root page') do
+  @test_site.shadow_root.load
+end
+
 Then('I am on the home page') do
   expect(@test_site.home).to be_displayed
 end

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -153,6 +153,9 @@ Then('I can see elements from the block') do
 end
 
 Then('I can see elements from the section composed of a shadow root') do
+  # Skip if using Capybara that does not support shadow_root
+  require_version = '3.37.0'
+  next if Capybara::VERSION < require_version
+
   expect(@test_site.shadow_root.shadow_root_section).to have_some_text
-rescue SitePrism::UnsupportedGemVersionError
 end

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -152,6 +152,6 @@ Then('I can see elements from the block') do
   expect(@test_site.home.people).to have_headline_clone
 end
 
-Then('I can see elements from the section composed of shadow roots') do
+Then('I can see elements from the section composed of a shadow root') do
   expect(@test_site.shadow_root.shadow_root_section).to have_some_text
 end

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -153,9 +153,7 @@ Then('I can see elements from the block') do
 end
 
 Then('I can see elements from the section composed of a shadow root') do
-  # Skip if using Capybara that does not support shadow_root
-  require_version = '3.37.0'
-  next if Capybara::VERSION < require_version
+  skip_this_scenario('Minimum Capybara version not reached. Scenario will not pass') if Capybara::VERSION < '3.37.0'
 
   expect(@test_site.shadow_root.shadow_root_section).to have_some_text
 end

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -154,4 +154,5 @@ end
 
 Then('I can see elements from the section composed of a shadow root') do
   expect(@test_site.shadow_root.shadow_root_section).to have_some_text
+rescue SitePrism::UnsupportedGemVersionError
 end

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -152,6 +152,6 @@ Then('I can see elements from the block') do
   expect(@test_site.home.people).to have_headline_clone
 end
 
-Then('I can see elements from the section composed of Shadow Root') do
+Then('I can see elements from the section composed of shadow roots') do
   expect(@test_site.shadow_root.shadow_root_section).to have_some_text
 end

--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -151,3 +151,7 @@ end
 Then('I can see elements from the block') do
   expect(@test_site.home.people).to have_headline_clone
 end
+
+Then('I can see elements from the section composed of Shadow Root') do
+  expect(@test_site.shadow_root.shadow_root_section).to have_some_text
+end

--- a/features/support/pages/shadow_root.rb
+++ b/features/support/pages/shadow_root.rb
@@ -5,7 +5,7 @@ class ShadowRoot < SitePrism::Page
   set_url_matcher(/shadow_root\.htm$/)
 
   # shadow-root
-  section :shadow_root_section, '#shadow-root', :shadow_root do
+  section :shadow_root_section, '#shadow-root', shadow_root: true do
     element :some_text, 'p'
   end
 end

--- a/features/support/pages/shadow_root.rb
+++ b/features/support/pages/shadow_root.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ShadowRoot < SitePrism::Page
+  set_url '/shadow_root.htm'
+  set_url_matcher(/shadow_root\.htm$/)
+
+  # shadow-root
+  section :shadow_root_section, '#shadow-root', :shadow_root do
+    element :some_text, 'p'
+  end
+end

--- a/features/support/pages/shadow_root.rb
+++ b/features/support/pages/shadow_root.rb
@@ -4,7 +4,6 @@ class ShadowRoot < SitePrism::Page
   set_url '/shadow_root.htm'
   set_url_matcher(/shadow_root\.htm$/)
 
-  # shadow-root
   section :shadow_root_section, '#shadow-root', shadow_root: true do
     element :some_text, 'p'
   end

--- a/features/support/test_site.rb
+++ b/features/support/test_site.rb
@@ -29,15 +29,15 @@ class TestSite
     @redirect ||= Redirect.new
   end
 
+  def shadow_root
+    @shadow_root ||= ShadowRoot.new
+  end
+
   def slow
     @slow ||= Slow.new
   end
 
   def vanishing
     @vanishing ||= Vanishing.new
-  end
-
-  def shadow_root
-    @shadow_root ||= ShadowRoot.new
   end
 end

--- a/features/support/test_site.rb
+++ b/features/support/test_site.rb
@@ -36,4 +36,8 @@ class TestSite
   def vanishing
     @vanishing ||= Vanishing.new
   end
+
+  def shadow_root
+    @shadow_root ||= ShadowRoot.new
+  end
 end

--- a/lib/site_prism/dsl/locators.rb
+++ b/lib/site_prism/dsl/locators.rb
@@ -13,7 +13,7 @@ module SitePrism
 
       def _find(*find_args)
         kwargs = find_args.pop
-        is_shadow_root = find_args.delete(:shadow_root)
+        is_shadow_root = find_args.delete(:shadow_root) { false }
         el = to_capybara_node.find(*find_args, **kwargs)
         return el.shadow_root if is_shadow_root
 

--- a/lib/site_prism/dsl/locators.rb
+++ b/lib/site_prism/dsl/locators.rb
@@ -14,6 +14,7 @@ module SitePrism
       def _find(*find_args)
         kwargs = find_args.pop
         shadow_root = kwargs.delete(:shadow_root) { false }
+        check_capybara_version_if_creating_shadow_root if shadow_root
         to_capybara_node.find(*find_args, **kwargs).tap do |element|
           break element.shadow_root if shadow_root
         end
@@ -67,6 +68,18 @@ module SitePrism
         options.merge!(find_args.pop) if find_args.last.is_a? Hash
         options.merge!(runtime_args.pop) if runtime_args.last.is_a? Hash
         options[:wait] = Capybara.default_max_wait_time unless options.key?(:wait)
+      end
+
+      def check_capybara_version_if_creating_shadow_root
+        require_version = '3.37.0'
+        return if Capybara::VERSION >= require_version
+
+        SitePrism.logger.error(
+          "Shadow root support requires Capybara version >= #{require_version}. " \
+          "You are using #{Capybara::VERSION}."
+        )
+
+        raise SitePrism::UnsupportedGemVersionError
       end
     end
   end

--- a/lib/site_prism/dsl/locators.rb
+++ b/lib/site_prism/dsl/locators.rb
@@ -13,7 +13,7 @@ module SitePrism
 
       def _find(*find_args)
         kwargs = find_args.pop
-        is_shadow_root = find_args.delete(:shadow_root) { false }
+        is_shadow_root = kwargs.delete(:shadow_root) { false }
         el = to_capybara_node.find(*find_args, **kwargs)
         return el.shadow_root if is_shadow_root
 
@@ -26,14 +26,14 @@ module SitePrism
       end
 
       def element_exists?(*find_args)
-        find_args.delete(:shadow_root)
         kwargs = find_args.pop
+        kwargs.delete(:shadow_root)
         to_capybara_node.has_selector?(*find_args, **kwargs)
       end
 
       def element_does_not_exist?(*find_args)
-        find_args.delete(:shadow_root)
         kwargs = find_args.pop
+        kwargs.delete(:shadow_root)
         to_capybara_node.has_no_selector?(*find_args, **kwargs)
       end
 

--- a/lib/site_prism/dsl/locators.rb
+++ b/lib/site_prism/dsl/locators.rb
@@ -13,7 +13,11 @@ module SitePrism
 
       def _find(*find_args)
         kwargs = find_args.pop
-        to_capybara_node.find(*find_args, **kwargs)
+        is_shadow_root = find_args.delete(:shadow_root)
+        el = to_capybara_node.find(*find_args, **kwargs)
+        return el.shadow_root if is_shadow_root
+
+        el
       end
 
       def _all(*find_args)
@@ -22,11 +26,13 @@ module SitePrism
       end
 
       def element_exists?(*find_args)
+        find_args.delete(:shadow_root)
         kwargs = find_args.pop
         to_capybara_node.has_selector?(*find_args, **kwargs)
       end
 
       def element_does_not_exist?(*find_args)
+        find_args.delete(:shadow_root)
         kwargs = find_args.pop
         to_capybara_node.has_no_selector?(*find_args, **kwargs)
       end

--- a/lib/site_prism/dsl/locators.rb
+++ b/lib/site_prism/dsl/locators.rb
@@ -13,11 +13,10 @@ module SitePrism
 
       def _find(*find_args)
         kwargs = find_args.pop
-        is_shadow_root = kwargs.delete(:shadow_root) { false }
-        el = to_capybara_node.find(*find_args, **kwargs)
-        return el.shadow_root if is_shadow_root
-
-        el
+        shadow_root = kwargs.delete(:shadow_root) { false }
+        to_capybara_node.find(*find_args, **kwargs).tap do |element|
+          break element.shadow_root if shadow_root
+        end
       end
 
       def _all(*find_args)

--- a/lib/site_prism/dsl/locators.rb
+++ b/lib/site_prism/dsl/locators.rb
@@ -71,15 +71,10 @@ module SitePrism
       end
 
       def check_capybara_version_if_creating_shadow_root
-        require_version = '3.37.0'
-        return if Capybara::VERSION >= require_version
+        minimum_version = '3.37.0'
+        raise SitePrism::UnsupportedGemVersionError unless Capybara::VERSION >= minimum_version
 
-        SitePrism.logger.error(
-          "Shadow root support requires Capybara version >= #{require_version}. " \
-          "You are using #{Capybara::VERSION}."
-        )
-
-        raise SitePrism::UnsupportedGemVersionError
+        SitePrism.logger.error("Shadow root support requires Capybara version >= #{minimum_version}. You are using #{Capybara::VERSION}.")
       end
     end
   end

--- a/lib/site_prism/error.rb
+++ b/lib/site_prism/error.rb
@@ -50,4 +50,7 @@ module SitePrism
 
   # DSL items are not permitted to be named in certain ways
   class InvalidDSLNameError < AttributeValidationError; end
+
+  # The version of the target gem is unsupported, so using that feature is not possible
+  class UnsupportedGemVersionError < SitePrismError; end
 end

--- a/test_site/shadow_root.htm
+++ b/test_site/shadow_root.htm
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <script type="text/javascript">
+      function load() {
+        // insert a Shadow Root
+        let element = document.getElementById('shadow-root');
+        let shadow = element.attachShadow({mode: 'open'});
+        let para = document.createElement('p');
+        let node = document.createTextNode('Some text in a shadow-root');
+        para.appendChild(node);
+        shadow.appendChild(para);
+      }
+      window.onload = load;
+    </script>
+  </head>
+  <body>
+    <div id="shadow-root"></div>
+  </body>
+</html>


### PR DESCRIPTION
Since there was no direct way to define Shadow Root in SitePrism, I handled it by adding an option.

I would appreciate it if you could inform me about the following concerns:
- When obtaining the Shadow Root, I am using the `Capybara::Node::Element#shadow_root` method, which requires Capybara version 3.37.0 or later. It also requires Ruby version 2.7 or later. Therefore, may I change the `required_ruby_version` in SitePrism? Are there any alternative solutions available? 
(I was also considering making changes to determine the availability of `:shadow_root` based on the Ruby version.)
FYI: https://github.com/teamcapybara/capybara/blob/master/History.md#version-3370
- In the current implementation, the inclusion of `:shadow_root` as an argument in the existing section method allows for achieving the functionality. However, do you think it would be better to separate it into a separate method, similar to iframe?

This is my first time contributing to an OSS, so I may have other areas where I lack experience. Nevertheless, I appreciate your support and guidance. Thank you :)