### PR TITLE
correct minor rubocop failure

### DIFF
--- a/features/step_definitions/section_steps.rb
+++ b/features/step_definitions/section_steps.rb
@@ -58,7 +58,7 @@ Then('access to elements is constrained to those within the section') do
   expect(@test_site.home.has_welcome_message?).to be true
 
   @test_site.home.people.within do |section|
-    expect(section).not_to have_css('.welcome')
+    expect(section).to have_no_css('.welcome')
 
     expect { section.has_welcome_message? }.to raise_error(NoMethodError)
   end


### PR DESCRIPTION
Quick fix for the red on main related to a Capybara/NegationMatcher rule.

This rule *used to* have performance implications but I don't believe it does anymore.  I think it just ensures homogeneity now so I'd be ok with disabling it.