### PR TITLE
Fix webdriver instantiation for cucumber tests

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,7 @@ require 'automation_helpers/drivers/local'
 require 'capybara'
 require 'capybara/cucumber'
 require 'selenium-webdriver'
+require 'webdrivers'
 
 $LOAD_PATH << './lib'
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,7 +19,8 @@ require_relative 'sections/all'
 
 SimpleCov.start if defined?(SimpleCov) && RUBY_VERSION < '3.1'
 
-browser = ENV.fetch('BROWSER', 'chrome').to_sym
+browser = ENV.fetch('BROWSER', 'firefox').to_sym
+ENV['HEADLESS'] = 'true'
 
 options =
   if browser == :chrome
@@ -30,7 +31,7 @@ options =
       opts.add_argument('--disable-gpu')
     end
   else
-    Selenium::WebDriver::Firefox::Options.new.tap { |opts| opts.add_argument('-headless') }
+    AutomationHelpers::Drivers::V4::Options.for(:firefox)
   end
 
 Capybara.register_driver :site_prism do |app|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -28,7 +28,6 @@ options =
     options.tap do |opts|
       opts.add_argument('--headless=new')
       opts.add_argument('--no-sandbox')
-      opts.add_argument('--disable-dev-shm-usage')
       opts.add_argument('--disable-gpu')
     end
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,7 +19,7 @@ require_relative 'sections/all'
 
 SimpleCov.start if defined?(SimpleCov) && RUBY_VERSION < '3.1'
 
-browser = ENV.fetch('BROWSER', 'firefox').to_sym
+browser = ENV.fetch('BROWSER', 'chrome').to_sym
 ENV['HEADLESS'] = 'true'
 options = AutomationHelpers::Drivers::V4::Options.for(browser)
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,15 +19,18 @@ require_relative 'sections/all'
 SimpleCov.start if defined?(SimpleCov) && RUBY_VERSION < '3.1'
 
 browser = ENV.fetch('BROWSER', 'chrome').to_sym
-options = AutomationHelpers::Drivers::V4::Options.for(browser)
 
-if browser == :chrome
-  options.tap do |opts|
-    opts.add_argument('--no-sandbox')
-    opts.add_argument('--disable-dev-shm-usage')
-    opts.add_argument('--disable-gpu')
+options =
+  if browser == :chrome
+    Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+      opts.add_argument('--headless=new')
+      opts.add_argument('--no-sandbox')
+      opts.add_argument('--disable-dev-shm-usage')
+      opts.add_argument('--disable-gpu')
+    end
+  else
+    Selenium::WebDriver::Firefox::Options.new.tap { |opts| opts.add_argument('-headless') }
   end
-end
 
 Capybara.register_driver :site_prism do |app|
   Capybara::Selenium::Driver.new(

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,17 +21,16 @@ SimpleCov.start if defined?(SimpleCov) && RUBY_VERSION < '3.1'
 
 browser = ENV.fetch('BROWSER', 'firefox').to_sym
 ENV['HEADLESS'] = 'true'
+options = AutomationHelpers::Drivers::V4::Options.for(browser)
 
 options =
   if browser == :chrome
-    Selenium::WebDriver::Chrome::Options.new.tap do |opts|
+    options.tap do |opts|
       opts.add_argument('--headless=new')
       opts.add_argument('--no-sandbox')
       opts.add_argument('--disable-dev-shm-usage')
       opts.add_argument('--disable-gpu')
     end
-  else
-    AutomationHelpers::Drivers::V4::Options.for(:firefox)
   end
 
 Capybara.register_driver :site_prism do |app|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,14 +23,13 @@ browser = ENV.fetch('BROWSER', 'chrome').to_sym
 ENV['HEADLESS'] = 'true'
 options = AutomationHelpers::Drivers::V4::Options.for(browser)
 
-options =
-  if browser == :chrome
-    options.tap do |opts|
-      opts.add_argument('--headless=new')
-      opts.add_argument('--no-sandbox')
-      opts.add_argument('--disable-gpu')
-    end
+if browser == :chrome
+  options.tap do |opts|
+    opts.add_argument('--headless=new')
+    opts.add_argument('--no-sandbox')
+    opts.add_argument('--disable-gpu')
   end
+end
 
 Capybara.register_driver :site_prism do |app|
   Capybara::Selenium::Driver.new(

--- a/site_prism.gemspec
+++ b/site_prism.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '~> 2.25.0'
   s.add_development_dependency 'selenium-webdriver', '~> 4.7'
   s.add_development_dependency 'simplecov', '~> 0.21'
+  s.add_development_dependency 'webdrivers', '~> 5.3'
 end


### PR DESCRIPTION
Revert to legacy way of creating driver