### PR TITLE
`wait_until_invisible` method for a section object 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1059,9 +1059,10 @@ expect(@home).not_to have_menu
 Like an element, it is possible to wait for a section to become visible
 or invisible. Calling the `section` method creates two methods on the
 relevant page or section:
-`wait_until_<section_name>_visible` and
-`wait_until_<section_name>_invisible`. Using the above example, here's
-how they're used:
+* `wait_until_<section_name>_visible`
+* `wait_until_<section_name>_invisible`
+
+Using the above example, here's how they're used:
 
 ```ruby
 @home = Home.new
@@ -1077,6 +1078,17 @@ time to wait for visibility/invisibility of a section. Here's how:
 @home = Home.new
 @home.wait_until_menu_visible(wait: 5)
 # and...
+@home.wait_until_menu_invisible(wait: 3)
+```
+
+You can also call `wait_until_invisible` directly on a section object.
+```ruby
+@home = Home.new
+@home.menu.tap do |menu|
+  # some actions with a menu object
+  menu.wait_until_invisible(wait: 3)
+end
+# is the same as
 @home.wait_until_menu_invisible(wait: 3)
 ```
 

--- a/features/section_explicit_waiting.feature
+++ b/features/section_explicit_waiting.feature
@@ -15,13 +15,21 @@ Feature: Waiting for a Section
     When I navigate to the home page
     Then an exception is raised when I wait for a section that won't appear
 
-  Scenario: Wait for Section Invisibility - Positive - Default Timeout
-    When I wait for the section that takes a while to vanish
+  Scenario Outline: Wait for Section Invisibility - Positive - Default Timeout
+    When I wait for the section that takes a while to vanish from <from> section
     Then the section is no longer visible
+    Examples:
+      | from   |
+      | this   |
+      | parent |
 
-  Scenario: Wait for Section Invisibility - Positive - Overridden Timeout
-    When I wait an overridden time for the section to vanish
+  Scenario Outline: Wait for Section Invisibility - Positive - Overridden Timeout
+    When I wait an overridden time for the section to vanish from <from> section
     Then the section is no longer visible
+    Examples:
+      | from   |
+      | this   |
+      | parent |
 
   @slow-test
   Scenario: Wait for Section Invisibility - Negative - Default Timeout

--- a/features/section_explicit_waiting.feature
+++ b/features/section_explicit_waiting.feature
@@ -16,7 +16,7 @@ Feature: Waiting for a Section
     Then an exception is raised when I wait for a section that won't appear
 
   Scenario Outline: Wait for Section Invisibility - Positive - Default Timeout
-    When I wait for the section that takes a while to vanish from <from> section
+    When I wait for the section that takes a while to vanish when calling from <from> section
     Then the section is no longer visible
     Examples:
       | from   |
@@ -24,7 +24,7 @@ Feature: Waiting for a Section
       | parent |
 
   Scenario Outline: Wait for Section Invisibility - Positive - Overridden Timeout
-    When I wait an overridden time for the section to vanish from <from> section
+    When I wait an overridden time for the section to vanish when calling from <from> section
     Then the section is no longer visible
     Examples:
       | from   |
@@ -32,8 +32,17 @@ Feature: Waiting for a Section
       | parent |
 
   @slow-test
-  Scenario: Wait for Section Invisibility - Negative - Default Timeout
-    Then an error is raised when waiting for the section to vanish
+  Scenario Outline: : Wait for Section Invisibility - Negative - Default Timeout
+    Then an error is raised when waiting for the section to vanish when calling from <from> section
+    Examples:
+      | from   |
+      | this   |
+      | parent |
 
-  Scenario: Wait for Section Invisibility - Negative - Overridden Timeout
-    Then an error is raised when waiting an overridden time for the section to vanish
+  Scenario Outline: Wait for Section Invisibility - Negative - Overridden Timeout
+    Then an error is raised when waiting an overridden time for the section to vanish when calling from <from> section
+    Examples:
+      | from   |
+      | this   |
+      | parent |
+

--- a/features/step_definitions/section_explicit_waiting_steps.rb
+++ b/features/step_definitions/section_explicit_waiting_steps.rb
@@ -4,8 +4,14 @@ When('I wait an overridden time for the section that takes a while to appear') d
   @test_site.slow.first_section(wait: upper_bound_delay)
 end
 
-When('I wait for the section that takes a while to vanish') do
-  @test_site.vanishing.wait_until_delayed_section_invisible
+When(/^I wait for the section that takes a while to vanish from (parent|this) section$/) do |from|
+  @test_site.vanishing.tap do |vanishing|
+    if from == 'parent'
+      vanishing.wait_until_delayed_section_invisible
+    else
+      vanishing.delayed_section.wait_until_invisible
+    end
+  end
 end
 
 Then("an exception is raised when I wait for a section that won't appear") do
@@ -21,8 +27,14 @@ Then('the section is no longer visible') do
   expect(@test_site.vanishing.delayed_section).not_to be_visible
 end
 
-When('I wait an overridden time for the section to vanish') do
-  @test_site.vanishing.wait_until_delayed_section_invisible(wait: upper_bound_delay)
+When(/^I wait an overridden time for the section to vanish from (this|parent) section$/) do |from|
+  @test_site.vanishing.tap do |vanishing|
+    if from == 'parent'
+      vanishing.wait_until_delayed_section_invisible(wait: upper_bound_delay)
+    else
+      vanishing.delayed_section.wait_until_invisible(wait: upper_bound_delay)
+    end
+  end
 end
 
 Then('the slow section appears') do

--- a/features/support/parameter_types.rb
+++ b/features/support/parameter_types.rb
@@ -1,0 +1,4 @@
+ParameterType(name: 'is_parent_section',
+              regexp: /(this|parent)/,
+              type: [TrueClass, FalseClass],
+              transformer: ->(value) { value == 'parent' })

--- a/lib/site_prism/dsl/methods.rb
+++ b/lib/site_prism/dsl/methods.rb
@@ -57,7 +57,7 @@ module SitePrism
         build(:section, name, *find_args) do
           define_method(name) do |*runtime_args, &runtime_block|
             section_element = _find(*merge_args(find_args, runtime_args))
-            section_class.new(self, section_element, &runtime_block)
+            section_class.new(self, section_element, name, &runtime_block)
           end
         end
       end
@@ -73,7 +73,7 @@ module SitePrism
           define_method(name) do |*runtime_args, &runtime_block|
             raise_if_runtime_block_supplied(self, name, runtime_block, :sections)
             _all(*merge_args(find_args, runtime_args)).map do |element|
-              section_class.new(self, element)
+              section_class.new(self, element, name)
             end
           end
         end

--- a/lib/site_prism/section.rb
+++ b/lib/site_prism/section.rb
@@ -40,9 +40,10 @@ module SitePrism
       end
     end
 
-    def initialize(parent, root_element, &block)
+    def initialize(parent, root_element, element_name = nil, &block)
       @parent = parent
       @root_element = root_element
+      @element_name = element_name
       within(&block) if block
     end
 
@@ -80,6 +81,10 @@ module SitePrism
       candidate = parent
       candidate = candidate.parent until candidate.is_a?(SitePrism::Page)
       candidate
+    end
+
+    def wait_until_invisible(*args, **kwargs)
+      parent.public_send("wait_until_#{@element_name}_invisible", *args, **kwargs)
     end
   end
 end

--- a/spec/site_prism/section_spec.rb
+++ b/spec/site_prism/section_spec.rb
@@ -349,4 +349,12 @@ describe SitePrism::Section do
       expect { section.new(SitePrism::Page.new, locator) }.to raise_error(SitePrism::InvalidElementError)
     end
   end
+
+  describe '#wait_until_invisible' do
+    let(:parent) { SitePrism::Page.new }
+    let(:section) { described_class.new(parent, '.locator', :section_name) }
+    subject { section }
+
+    it { is_expected.to respond_to(:wait_until_invisible) }
+  end
 end


### PR DESCRIPTION
This merge request introduces a new `wait_until_invisible` method for `Section` objects, allowing direct invocation of invisibility waits on individual sections.