### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/site-prism/site_prism/security/code-scanning/1](https://github.com/site-prism/site_prism/security/code-scanning/1)

In general, fix this by explicitly specifying a `permissions:` block that restricts the `GITHUB_TOKEN` to the minimal scopes needed. This can be done at the workflow root (applies to all jobs) or per job. Since there is a single job and it only reads repository contents, `contents: read` is sufficient.

The best fix here is to add a workflow-level `permissions:` block after the `name: CI` line in `.github/workflows/ci.yml`. This will apply to the `test` job without changing any existing behavior, while ensuring the token is read-only. No additional imports or methods are required; this is purely a YAML configuration change.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the current lines 2 and 3. All existing `on:` and `jobs:` sections remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
